### PR TITLE
fix: Add generate.routes '/' per dev recommendation

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -6,6 +6,9 @@ module.exports = {
     port: '3000',
     host: '0.0.0.0',
   },
+  generate: {
+    routes: ['/'],
+  },
   head: {
     htmlAttrs: {
       lang: 'en',


### PR DESCRIPTION
This pull request adds `generate.routes` option to `nuxt.config.js` in hope to fix Netlify deployment issue.