### PR TITLE
build: Set fallback to true to correct fallback handling

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -8,6 +8,7 @@ module.exports = {
   },
   generate: {
     routes: ['/'],
+    fallback: true,
   },
   head: {
     htmlAttrs: {


### PR DESCRIPTION
This pull request sets `fallback` option from `generate` object to `true`, as it seems that most static deployments incorrectly parses `200.html` as homepage instead of fallback content.