### PR TITLE
build: Remove 'routes' options

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -7,7 +7,6 @@ module.exports = {
     host: '0.0.0.0',
   },
   generate: {
-    routes: ['/'],
     fallback: true,
   },
   head: {


### PR DESCRIPTION
This pull request removes `generate.routes` from the option as it was unnecessary.