### PR TITLE
fix: Changed html tags to correct semantics

### DIFF
--- a/src/layouts/blank.vue
+++ b/src/layouts/blank.vue
@@ -29,7 +29,9 @@ export default {
 </script>
 
 <template>
-  <nuxt />
+  <main class="tracking-manrope">
+    <nuxt />
+  </main>
 </template>
 
 <style scoped></style>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -53,7 +53,9 @@ export default {
   <div
     class="flex flex-col
     bg-background-primary
-    text-copy antialiased
+    text-copy
+    antialiased
+    tracking-manrope
     app"
     :class="`theme-${theme}`"
   >

--- a/src/pages/under-construction.vue
+++ b/src/pages/under-construction.vue
@@ -26,7 +26,7 @@ export default {
 </script>
 
 <template>
-  <main class="screen
+  <section class="screen
     bg-dark
     flex flex-col items-center justify-center
     font-medium
@@ -42,7 +42,7 @@ export default {
         />
       </div>
 
-      <section class="disclaimer tracking-manrope px-6 py-8 md:p-0">
+      <article class="disclaimer px-6 py-8 md:p-0">
         <h1 class="font-semibold
           head
           mb-8
@@ -73,8 +73,8 @@ export default {
             Feeling adventurous yet?
           </a>
         </div>
-      </section>
-  </main>
+      </article>
+  </section>
 </template>
 
 <style lang="postcss" scoped>


### PR DESCRIPTION
This pull request fixes incorrect semantics for `under-construction` page.

It also adds `tracking-manrope` magic variable for recommended Manrope font spacing